### PR TITLE
Add minimum args check

### DIFF
--- a/cmd/kvdb/main.go
+++ b/cmd/kvdb/main.go
@@ -39,6 +39,7 @@ func main() {
 	Run("substreams-sink-kv", "KVDB Client",
 		ConfigureViper("KVDB"),
 		ConfigureVersion(),
+		MinimumNArgs(1),
 
 		Group("read", "KVDB read commands",
 			ReadGetCmd,


### PR DESCRIPTION
Running `kvdb` without arguments would panic instead of showing usage:
```
➜  kvdb git:(develop) ✗ kvdb
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x100b373c4]
```

Added `MinimumNArgs(1)` to prevent that 